### PR TITLE
feat: use Logo.png as company logo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,12 @@ HCTwebsite/
   index.html    — Main page
   style.css     — Styling and animations
   script.js     — Interactive behaviour
+  Logo.png      — Company logo (used in nav and footer)
 ```
+
+## Assets
+
+- **Logo:** `HCTwebsite/Logo.png` — The official company logo. Use this image wherever the company logo is displayed (navigation bar, footer, etc.).
 
 ## Contact Details
 

--- a/HCTwebsite/index.html
+++ b/HCTwebsite/index.html
@@ -12,7 +12,7 @@
   <header class="nav" id="nav">
     <div class="nav__inner container">
       <a href="#hero" class="nav__logo">
-        <span class="nav__logo-icon">✦</span> Harry's Clean Team
+        <img src="Logo.png" alt="Harry's Clean Team" class="nav__logo-img" />
       </a>
       <nav class="nav__links">
         <a href="#services">Services</a>
@@ -305,7 +305,7 @@
   <footer class="footer">
     <div class="container footer__inner">
       <div class="footer__brand">
-        <span class="nav__logo-icon">✦</span>
+        <img src="Logo.png" alt="Harry's Clean Team" class="footer__logo-img" />
         <strong>Harry's Clean Team</strong>
         <p>Professional cleaning services across Castlemaine, Melbourne and Daylesford.</p>
       </div>

--- a/HCTwebsite/style.css
+++ b/HCTwebsite/style.css
@@ -153,6 +153,19 @@ button { cursor: pointer; font-family: inherit; border: none; background: none; 
   font-size: 1.2rem;
 }
 
+.nav__logo-img {
+  height: 44px;
+  width: auto;
+  display: block;
+}
+
+.footer__logo-img {
+  height: 56px;
+  width: auto;
+  display: block;
+  margin-bottom: .5rem;
+}
+
 .nav__links {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Use Logo.png as the company logo in the navigation bar and footer, with CSS sizing classes added. CLAUDE.md updated to document the asset.

Closes #6

Generated with [Claude Code](https://claude.ai/code)