### PR TITLE
Fix footer logo aspect ratio

### DIFF
--- a/HCTwebsite/style.css
+++ b/HCTwebsite/style.css
@@ -164,6 +164,7 @@ button { cursor: pointer; font-family: inherit; border: none; background: none; 
   width: auto;
   display: block;
   margin-bottom: .5rem;
+  align-self: flex-start;
 }
 
 .nav__links {


### PR DESCRIPTION
Fix the stretched company logo in the footer section.

The footer brand container uses flex column layout with default `align-items: stretch`, which caused the logo image to stretch its width to fill the container, distorting the aspect ratio. Added `align-self: flex-start` to `.footer__logo-img` to fix this.

Closes #8

Generated with [Claude Code](https://claude.ai/code)