### PR TITLE
Update 'What We Do' section: rename residential and remove cards

### DIFF
--- a/HCTwebsite/index.html
+++ b/HCTwebsite/index.html
@@ -76,24 +76,12 @@
 
         <article class="service-card">
           <div class="service-card__icon">🏠</div>
-          <h3>Residential Cleaning</h3>
+          <h3>Short term rental</h3>
           <p>Regular weekly, bi-weekly, or monthly home cleans. Every room, every surface — handled with care.</p>
           <ul>
             <li>Kitchens &amp; bathrooms</li>
             <li>Bedrooms &amp; living areas</li>
             <li>Floors, dusting &amp; vacuuming</li>
-          </ul>
-        </article>
-
-        <article class="service-card service-card--featured">
-          <div class="service-card__badge">Most Popular</div>
-          <div class="service-card__icon">✨</div>
-          <h3>Deep Clean</h3>
-          <p>A thorough top-to-bottom clean for homes that need extra attention — perfect for move-in/out or spring cleans.</p>
-          <ul>
-            <li>Inside appliances &amp; cabinets</li>
-            <li>Grout, tiles &amp; hard-to-reach areas</li>
-            <li>Full sanitisation</li>
           </ul>
         </article>
 
@@ -105,28 +93,6 @@
             <li>Offices &amp; retail spaces</li>
             <li>Common areas &amp; restrooms</li>
             <li>After-hours available</li>
-          </ul>
-        </article>
-
-        <article class="service-card">
-          <div class="service-card__icon">📦</div>
-          <h3>Move In / Move Out</h3>
-          <p>Start fresh or leave on a great note. We make sure every corner is spotless for the next chapter.</p>
-          <ul>
-            <li>Full property clean</li>
-            <li>Bond-back guarantee support</li>
-            <li>Flexible scheduling</li>
-          </ul>
-        </article>
-
-        <article class="service-card">
-          <div class="service-card__icon">🪟</div>
-          <h3>Window Cleaning</h3>
-          <p>Crystal-clear windows inside and out. Natural light the way it should be.</p>
-          <ul>
-            <li>Interior &amp; exterior</li>
-            <li>Streak-free finish</li>
-            <li>Screens &amp; sills included</li>
           </ul>
         </article>
 
@@ -282,11 +248,8 @@
             <label for="service">Service Needed</label>
             <select id="service" name="service">
               <option value="">Select a service…</option>
-              <option>Residential Cleaning</option>
-              <option>Deep Clean</option>
+              <option>Short term rental</option>
               <option>Commercial Cleaning</option>
-              <option>Move In / Move Out</option>
-              <option>Window Cleaning</option>
               <option>Eco-Friendly Clean</option>
             </select>
           </div>
@@ -311,10 +274,9 @@
       </div>
       <div class="footer__links">
         <h5>Services</h5>
-        <a href="#services">Residential</a>
+        <a href="#services">Short term rental</a>
         <a href="#services">Commercial</a>
-        <a href="#services">Deep Clean</a>
-        <a href="#services">Move In/Out</a>
+        <a href="#services">Eco-Friendly Clean</a>
       </div>
       <div class="footer__links">
         <h5>Company</h5>


### PR DESCRIPTION
Closes #10

- Renamed "Residential Cleaning" heading to "Short term rental"
- Removed "Deep Clean", "Move In / Move Out", and "Window Cleaning" cards
- Updated contact form dropdown and footer links to match

Generated with [Claude Code](https://claude.ai/code)