### PR TITLE
Fix middle testimonial card rendering

### DIFF
--- a/HCTwebsite/index.html
+++ b/HCTwebsite/index.html
@@ -187,7 +187,7 @@
           </footer>
         </blockquote>
 
-        <blockquote class="testimonial testimonial--featured">
+        <blockquote class="testimonial">
           <div class="testimonial__stars">★★★★★</div>
           <p>"We use Harry's for our office and the results are consistently outstanding. The team is professional, thorough, and always reliable."</p>
           <footer>


### PR DESCRIPTION
Removes the `testimonial--featured` class from the middle testimonial card so all three cards in the #testimonials section render consistently.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)